### PR TITLE
[misc] update license expression in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "node": ">= 6.0"
   },
   "author": "Diego Dupin <diego.dupin@mariadb.com>",
-  "license": "LGPL-2.1+",
+  "license": "LGPL-2.1-or-later",
   "dependencies": {
     "@types/geojson": "^7946.0.7",
     "@types/node": "^12.12.11",


### PR DESCRIPTION
"LGPL-2.1+" is listed as deprecated in https://spdx.org/licenses/ and "LGPL-2.1-or-later" should be equivalent.