### PR TITLE
Fix require of Errors in 2 files.

### DIFF
--- a/lib/pool-callback.js
+++ b/lib/pool-callback.js
@@ -2,6 +2,7 @@
 
 const PoolBase = require('./pool-base');
 const ConnectionCallback = require('./connection-callback');
+const Errors = require('./misc/errors');
 const util = require('util');
 
 function PoolCallback(options) {

--- a/lib/pool-promise.js
+++ b/lib/pool-promise.js
@@ -2,6 +2,7 @@
 
 const Connection = require('./connection');
 const PoolBase = require('./pool-base');
+const Errors = require('./misc/errors');
 const util = require('util');
 
 function PoolPromise(options) {


### PR DESCRIPTION
Two files use Errors class without a require of misc/errors.js.

To see the issue in action:

```
const mariadb = require('mariadb');

const pool = mariadb.createPool({
    host: 'localhost',
    user: 'root',
    socketPath: '/run/mysqld/mysqld.sock',
});
var conn = pool.getConnection();
pool.end(); // Interrupts the pool get, which tries to throw an error and fails.
```

The node error:

> (node:6656) UnhandledPromiseRejectionWarning: ReferenceError: Errors is not defined