### PR TITLE
fix undefined localTz param

### DIFF
--- a/lib/cmd/resultset.js
+++ b/lib/cmd/resultset.js
@@ -98,6 +98,7 @@ class ResultSet extends Command {
       nestTables: cmdOpts.nestTables != undefined ? cmdOpts.nestTables : connOpts.nestTables,
       dateStrings: cmdOpts.dateStrings != undefined ? cmdOpts.dateStrings : connOpts.dateStrings,
       tz: cmdOpts.tz != undefined ? cmdOpts.tz : connOpts.tz,
+      localTz: cmdOpts.localTz != undefined ? cmdOpts.localTz : connOpts.localTz,
       namedPlaceholders:
         cmdOpts.namedPlaceholders != undefined
           ? cmdOpts.namedPlaceholders


### PR DESCRIPTION
closes #92

localTz param is undefined causing a crash. this change makes sure localTz param is not undefined.