### PR TITLE
Support passing null values in array when doing queries

### DIFF
--- a/lib/cmd/common-text-cmd.js
+++ b/lib/cmd/common-text-cmd.js
@@ -32,7 +32,9 @@ class CommonText extends ResultSet {
         out.writeStringAscii('' + value);
         break;
       case 'object':
-        if (Object.prototype.toString.call(value) === '[object Date]') {
+        if (value === null) {
+          out.writeStringAscii('NULL');
+        } else if (Object.prototype.toString.call(value) === '[object Date]') {
           out.writeStringAscii(this.getDateQuote(value, opts));
         } else if (Buffer.isBuffer(value)) {
           out.writeStringAscii("_BINARY '");

--- a/lib/cmd/query.js
+++ b/lib/cmd/query.js
@@ -66,13 +66,8 @@ class Query extends CommonText {
     for (let i = 1; i < len; i++) {
       const value = this.values[i - 1];
 
-      if (value === null) {
-        out.writeStringAscii('NULL');
-        out.writeString(this.queryParts[i]);
-        continue;
-      }
-
       if (
+        value !== null &&
         typeof value === 'object' &&
         typeof value.pipe === 'function' &&
         typeof value.read === 'function'

--- a/test/integration/test-query.js
+++ b/test/integration/test-query.js
@@ -65,6 +65,33 @@ describe('basic query', () => {
       })
       .catch(done);
   });
+  it('array parameter with null value', function (done) {
+    base
+      .createConnection()
+      .then((conn) => {
+        conn.query('CREATE TEMPORARY TABLE arrayParam (id int, val varchar(10))');
+        conn.query("INSERT INTO arrayParam VALUES ?", [[1, null]]);
+        conn.query("INSERT INTO arrayParam VALUES ?", [[2, 'a']]);
+        conn
+          .query('SELECT * FROM arrayParam')
+          .then((rows) => {
+            assert.deepEqual(rows, [
+              {
+                id: 1,
+                val: null
+              },
+              {
+                id: 2,
+                val: 'a'
+              }
+            ]);
+            conn.end();
+            done();
+          })
+          .catch(done);
+      })
+      .catch(done);
+  });
   it('permitSetMultiParamEntries set', (done) => {
     const jsonValue = { id: 1, val: 'test' };
     base


### PR DESCRIPTION
This commit fixes adding null values in a parameter array. For example in the command:

`connection.query('insert into my_table(col1, col2) values ?', ['val1', null])`