### PR TITLE
Fix "cannot mix BigInt and other types" error

### DIFF
--- a/lib/io/packet.js
+++ b/lib/io/packet.js
@@ -282,7 +282,7 @@ class Packet {
       result = result * 10n + BigInt(this.buf[begin] - 48);
     }
     this.pos += len;
-    return negate ? -1 * result : result;
+    return negate ? -1n * result : result;
   }
 
   readDecimalLengthEncoded() {


### PR DESCRIPTION
Hello,

I'm trying to update this library in sequelize (https://github.com/sequelize/sequelize/pull/14187), but the newer version crashes with `TypeError: Cannot mix BigInt and other types, use explicit conversions`.

The error is thrown by [this line](https://github.com/mariadb-corporation/mariadb-connector-nodejs/blob/master/lib/io/packet.js#L285):

```
return negate ? -1 * result : result;
```

According to the code, `result` is always a `BigInt`, so `-1 * result` will always throw. I've changed `-1` to `-1n` in the code and it resolved the issue.