### PR TITLE
Add checkNumberRange to TS types

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -135,6 +135,13 @@ export interface QueryConfig {
   bigIntAsNumber?: boolean;
 
   /**
+   * Throw if conversion to Number is not safe.
+   *
+   * Default: false;
+   */
+  checkNumberRange?: boolean;
+
+  /**
    * Configure logger
    */
   logger?: LoggerConfig;


### PR DESCRIPTION
As already mentioned here https://github.com/mariadb-corporation/mariadb-connector-nodejs/issues/201#issuecomment-1208211632, the new `checkNumberRange` option was not added to type definitions.