### PR TITLE
Modify unneeded `Object.entries()`

### DIFF
--- a/lib/pool.js
+++ b/lib/pool.js
@@ -435,8 +435,8 @@ class Pool extends EventEmitter {
 
   _leakedConnections() {
     let counter = 0;
-    for (const [key, value] of Object.entries(this.#activeConnections)) {
-      if (value && value.leaked) counter++;
+    for (const connection of Object.values(this.#activeConnections)) {
+      if (connection && connection.leaked) counter++;
     }
     return counter;
   }
@@ -474,8 +474,8 @@ class Pool extends EventEmitter {
    */
   activeConnections() {
     let counter = 0;
-    for (const [key, value] of Object.entries(this.#activeConnections)) {
-      if (value) counter++;
+    for (const connection of Object.values(this.#activeConnections)) {
+      if (connection) counter++;
     }
     return counter;
   }


### PR DESCRIPTION
Whilst browsing through the source code, I noticed occurrences where objects were being destructured into `[key, value]` pairs which were redudant, as only the `value` would be referenced. This pull request resolves these redundancies.