### PR TITLE
docs: update default value of connectTimeout since v2.5.6

### DIFF
--- a/documentation/callback-api.md
+++ b/documentation/callback-api.md
@@ -256,7 +256,7 @@ Essential options list:
 | **`database`** | Default database to use when establishing the connection. | *string* | 
 | **`socketPath`** | Permits connections to the database through the Unix domain socket or named pipe. |  *string* | 
 | **`compress`** | Compresses the exchange with the database through gzip.  This permits better performance when the database is not in the same location.  |*boolean*| false|
-| **`connectTimeout`** | Sets the connection timeout in milliseconds. |*integer* | 10 000|
+| **`connectTimeout`** | Sets the connection timeout in milliseconds. |*integer* | 1 000|
 | **`socketTimeout`** | Sets the socket timeout in milliseconds after connection succeeds. A value of `0` disables the timeout. |*integer* | 0|
 | **`queryTimeout`** | Set maximum query time in ms (an error will be thrown if limit is reached). 0 or undefined meaning no timeout. This can be superseded for a query using `timeout` option|*int* |0|
 | **`rowsAsArray`** | Returns result-sets as arrays, rather than JSON. This is a faster way to get results. For more information, see Query. |*boolean* | false|

--- a/documentation/promise-api.md
+++ b/documentation/promise-api.md
@@ -349,7 +349,7 @@ Essential options list:
 | **`database`** | Default database to use when establishing the connection. | *string* | 
 | **`socketPath`** | Permits connections to the database through the Unix domain socket or named pipe. |  *string* | 
 | **`compress`** | Compresses the exchange with the database through gzip.  This permits better performance when the database is not in the same location.  |*boolean*| false|
-| **`connectTimeout`** | Sets the connection timeout in milliseconds. |*integer* | 10 000|
+| **`connectTimeout`** | Sets the connection timeout in milliseconds. |*integer* | 1 000|
 | **`socketTimeout`** | Sets the socket timeout in milliseconds after connection succeeds. A value of `0` disables the timeout. |*integer* | 0|
 | **`queryTimeout`** | Set maximum query time in ms (an error will be thrown if limit is reached). 0 or undefined meaning no timeout. This can be superseded for a query using [`timeout`](https://github.com/mariadb-corporation/mariadb-connector-nodejs/blob/master/documentation/promise-api.md#timeout) option|*int* |0| 
 | **`rowsAsArray`** | Returns result-sets as arrays, rather than JSON. This is a faster way to get results. For more information, see Query. |*boolean* | false|


### PR DESCRIPTION
Both the [original commit](https://github.com/mariadb-corporation/mariadb-connector-nodejs/commit/16d45cd7b3d2201a252f9199afbb08f794ea2a69) and #193 missed changing the default value in `documentation/callback-api.md` and `documentation/promise-api.md`