### PR TITLE
Allow to pass type to query function

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -580,7 +580,7 @@ export interface Connection {
   /**
    * Execute query using text protocol.
    */
-  query(sql: string | QueryOptions, values?: any): Promise<any>;
+  query<T = any>(sql: string | QueryOptions, values?: any): Promise<T>;
 
   /**
    * Prepare query.


### PR DESCRIPTION
This helps to set output type instead of using "as" afterwords.