### PR TITLE
updating Node.js engine support to Node.js v14

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "callback.js"
   ],
   "engines": {
-    "node": ">= 12"
+    "node": ">= 14"
   },
   "author": "Diego Dupin <diego.dupin@mariadb.com>",
   "license": "LGPL-2.1-or-later",


### PR DESCRIPTION
- version 3.1.0 of mariadb appears to break compatibility with Node.js v12
- version 3.0.2 seems to not have the same syntax errors

Here's the output when I run the test suite with the latest Node.js v12 with 3.1.0:

```
/private/tmp/mariadb-connector-nodejs/lib/cmd/query.js:197
  #paramWritten(out, info) {
               ^

SyntaxError: Unexpected token '('
```