### PR TITLE
[misc] improve escape() general performance

### DIFF
--- a/lib/misc/utils.js
+++ b/lib/misc/utils.js
@@ -226,40 +226,19 @@ const escapeParameters = (opts, info, value) => {
 };
 
 // see https://mariadb.com/kb/en/library/string-literals/
-const LITTERAL_ESCAPE = {
-  '\u0000': '\\0',
+const LITERAL_ESCAPES = {
   "'": "\\'",
   '"': '\\"',
-  '\b': '\\b',
   '\n': '\\n',
   '\r': '\\r',
+  '\b': '\\b',
   '\t': '\\t',
-  '\u001A': '\\Z',
-  '\\': '\\\\'
+  '\\': '\\\\',
+  '\u0000': '\\0',
+  '\u001A': '\\Z'
 };
 
-const escapeString = (val) => {
-  const pattern = /[\u0000'"\b\n\r\t\u001A\\]/g;
-
-  let offset = 0;
-  let escaped = '';
-  let match;
-
-  while ((match = pattern.exec(val))) {
-    escaped += val.substring(offset, match.index);
-    escaped += LITTERAL_ESCAPE[match[0]];
-    offset = pattern.lastIndex;
-  }
-
-  if (offset === 0) {
-    return val;
-  }
-
-  if (offset < val.length) {
-    escaped += val.substring(offset);
-  }
-
-  return escaped;
-};
+const escapesRegExp = /['"\n\r\b\t\\\u0000\u001A]/g;
+const escapeString = (val) => val.replace(escapesRegExp, (character) => LITERAL_ESCAPES[character]);
 
 module.exports.escape = escapeParameters;

--- a/test/integration/test-pool-callback.js
+++ b/test/integration/test-pool-callback.js
@@ -359,6 +359,10 @@ describe('Pool callback', () => {
       assert.equal(pool.escapeId('f:a'), '`f:a`');
       assert.equal(pool.escapeId('`f:a`'), '`f:a`');
       assert.equal(pool.escapeId('good_`è`one'), '`good_``è``one`');
+      assert.equal(pool.escape('\x00\x1A'), "'\\0\\Z'");
+      assert.equal(pool.escape('\u0000\u001A'), "'\\0\\Z'");
+      assert.equal(pool.escape('\'"'), "'\\'\\\"'");
+      assert.equal(pool.escape('\b\n\r\t\\'), "'\\b\\n\\r\\t\\\\'");
       pool.end();
       pool2.end();
       done();

--- a/test/integration/test-pool.js
+++ b/test/integration/test-pool.js
@@ -225,6 +225,10 @@ describe('Pool', () => {
       assert.equal(pool.escapeId('f:a'), '`f:a`');
       assert.equal(pool.escapeId('`f:a`'), '`f:a`');
       assert.equal(pool.escapeId('good_`è`one'), '`good_``è``one`');
+      assert.equal(pool.escape('\x00\x1A'), "'\\0\\Z'");
+      assert.equal(pool.escape('\u0000\u001A'), "'\\0\\Z'");
+      assert.equal(pool.escape('\'"'), "'\\'\\\"'");
+      assert.equal(pool.escape('\b\n\r\t\\'), "'\\b\\n\\r\\t\\\\'");
       await pool.end();
       await pool2.end();
       done();


### PR DESCRIPTION
This PR optimizes `escape()` by using a single replacement RegExp instead of a hardcoded replacement. It is about **[~30% faster](https://perf.link/#eyJpZCI6IjFjZzlnaDVmbGkwIiwidGl0bGUiOiJGaW5kaW5nIG51bWJlcnMgaW4gYW4gYXJyYXkgb2YgMTAwMCIsImJlZm9yZSI6ImNvbnN0IExJVFRFUkFMX0VTQ0FQRSA9IHtcbiAgJ1xcdTAwMDAnOiAnXFxcXDAnLFxuICBcIidcIjogXCJcXFxcJ1wiLFxuICAnXCInOiAnXFxcXFwiJyxcbiAgJ1xcYic6ICdcXFxcYicsXG4gICdcXG4nOiAnXFxcXG4nLFxuICAnXFxyJzogJ1xcXFxyJyxcbiAgJ1xcdCc6ICdcXFxcdCcsXG4gICdcXHUwMDFBJzogJ1xcXFxaJyxcbiAgJ1xcXFwnOiAnXFxcXFxcXFwnXG59O1xuXG5jb25zdCBlc2NhcGVTdHJpbmcgPSAodmFsKSA9PiB7XG4gIGNvbnN0IHBhdHRlcm4gPSAvW1xcdTAwMDAnXCJcXGJcXG5cXHJcXHRcXHUwMDFBXFxcXF0vZztcblxuICBsZXQgb2Zmc2V0ID0gMDtcbiAgbGV0IGVzY2FwZWQgPSAnJztcbiAgbGV0IG1hdGNoO1xuXG4gIHdoaWxlICgobWF0Y2ggPSBwYXR0ZXJuLmV4ZWModmFsKSkpIHtcbiAgICBlc2NhcGVkICs9IHZhbC5zdWJzdHJpbmcob2Zmc2V0LCBtYXRjaC5pbmRleCk7XG4gICAgZXNjYXBlZCArPSBMSVRURVJBTF9FU0NBUEVbbWF0Y2hbMF1dO1xuICAgIG9mZnNldCA9IHBhdHRlcm4ubGFzdEluZGV4O1xuICB9XG5cbiAgaWYgKG9mZnNldCA9PT0gMCkge1xuICAgIHJldHVybiB2YWw7XG4gIH1cblxuICBpZiAob2Zmc2V0IDwgdmFsLmxlbmd0aCkge1xuICAgIGVzY2FwZWQgKz0gdmFsLnN1YnN0cmluZyhvZmZzZXQpO1xuICB9XG5cbiAgcmV0dXJuIGVzY2FwZWQ7XG59O1xuXG4vLyBWMjpcbmNvbnN0IGxpdGVyYWxFc2NhcGVzID0ge1xuICBcIidcIjogXCJcXFxcJ1wiLFxuICAnXCInOiAnXFxcXFwiJyxcbiAgXCJcXG5cIjogXCJcXFxcblwiLFxuICBcIlxcclwiOiBcIlxcXFxyXCIsXG4gIFwiXFxiXCI6IFwiXFxcXGJcIixcbiAgXCJcXHRcIjogXCJcXFxcdFwiLFxuICBcIlxcXFxcIjogXCJcXFxcXFxcXFwiLFxuICBcIlxcdTAwMDBcIjogXCJcXFxcMFwiLFxuICBcIlxcdTAwMUFcIjogXCJcXFxcWlwiLFxufTtcblxuY29uc3QgZXNjYXBlc1JlZ0V4cCA9IC9bJ1wiXFxuXFxyXFxiXFx0XFxcXFxcdTAwMDBcXHUwMDFBXS9nO1xuXG5jb25zdCBlc2NhcGVTdHJpbmdWMiA9ICh2YWx1ZSkgPT5cbiAgdmFsdWUucmVwbGFjZShlc2NhcGVzUmVnRXhwLCAoY2hhcmFjdGVyKSA9PiBsaXRlcmFsRXNjYXBlc1tjaGFyYWN0ZXJdKTsiLCJ0ZXN0cyI6W3sibmFtZSI6IlRlc3QgQ2FzZSIsImNvZGUiOiJlc2NhcGVTdHJpbmdWMignXFx4MDBcXHgxQScpO1xuZXNjYXBlU3RyaW5nVjIoJ1xcdTAwMDBcXHUwMDFBJyk7XG5lc2NhcGVTdHJpbmdWMignXFwnXCInKTtcbmVzY2FwZVN0cmluZ1YyKCdcXGJcXG5cXHJcXHRcXFxcJyk7XG5lc2NhcGVTdHJpbmdWMigndGVzdCcpOyIsInJ1bnMiOlsxMDAwMDAsNTMwMDAsMTM5MDAwLDEwMTAwMCwxNDkwMDAsMTE4MDAwLDIxMzAwMCwxMDAwLDE1NjAwMCw5MDAwLDE5ODAwMCwxOTMwMDAsMTE0MDAwLDEwMDAsOTkwMDAsMjkwMDAsODEwMDAsMTcyMDAwLDEyODAwMCw5MDAwMCwyOTAwMCwyMzUwMDAsMjIzMDAwLDkzMDAwLDE2OTAwMCw5MDAwLDEwMDAsMjQ5MDAwLDM3MDAwLDE1NzAwMCw0NjAwMCwxODcwMDAsMTAwMCwyNjAwMCw4MTAwMCwxMDAwLDE4NjAwMCwxNDUwMDAsODkwMDAsMzIwMDAsMTIwMDAwLDE4MjAwMCwxMjYwMDAsMTAwMCwxMTMwMDAsMTAwMCwyMDEwMDAsMTAwMCwxMzYwMDAsNTcwMDAsMTk1MDAwLDI0MTAwMCwxNjcwMDAsMTAwMCw1MDAwMCwxMDAwMDAsMTI2MDAwLDEyOTAwMCw1NDAwMCwyNTMwMDAsMTQ2MDAwLDEwMDAsMjMxMDAwLDQ3MDAwLDIwNTAwMCwxNTMwMDAsNjUwMDAsMTQ0MDAwLDE4OTAwMCwyMTMwMDAsOTcwMDAsOTQwMDAsODkwMDAsMjI2MDAwLDc5MDAwLDEwMzAwMCwxMDAwLDIzMzAwMCw0OTAwMCwxMDAwLDU4MDAwLDEwODAwMCwxMjcwMDAsMTAyMDAwLDEwMjAwMCwxMDAwLDExMzAwMCw3MzAwMCwxOTIwMDAsMTQwMDAsMjM3MDAwLDEwMDAsOTEwMDAsMzEwMDAsMjM4MDAwLDIwNDAwMCw5NzAwMCwxOTgwMDAsMTAwMCw2MzAwMF0sIm9wcyI6MTA4MTEwfSx7Im5hbWUiOiJUZXN0IENhc2UiLCJjb2RlIjoiZXNjYXBlU3RyaW5nKCdcXHgwMFxceDFBJyk7XG5lc2NhcGVTdHJpbmcoJ1xcdTAwMDBcXHUwMDFBJyk7XG5lc2NhcGVTdHJpbmcoJ1xcJ1wiJyk7XG5lc2NhcGVTdHJpbmcoJ1xcYlxcblxcclxcdFxcXFwnKTtcbmVzY2FwZVN0cmluZygndGVzdCcpOyIsInJ1bnMiOls4NDAwMCwyMjAwMCw0NTAwMCw2NDAwMCw2NTAwMCwxNjcwMDAsMTAwMCwxNjEwMDAsMTA3MDAwLDIwMDAsMTU2MDAwLDEwMDAsMTAwMCw3NDAwMCwxMDAwLDE0NjAwMCw4NzAwMCw0MzAwMCwxMDAwLDEwMDAsODkwMDAsMTAwMCwxNTEwMDAsNzMwMDAsNTUwMDAsMjAwMCwyNDAwMCwxNTMwMDAsODkwMDAsMTIwMDAsMTMxMDAwLDEyMDAwLDEzNzAwMCw3MDAwMCw1MDAwMCwyNjAwMCw1ODAwMCw5MzAwMCwxNjMwMDAsODMwMDAsMTAwMCwxMzIwMDAsNzAwMCwxNDUwMDAsMTAwMCwxNzkwMDAsMTUzMDAwLDM2MDAwLDI2MDAwLDE3NTAwMCw1NTAwMCw5OTAwMCwxMDAwLDExNzAwMCwyMDAwLDExMzAwMCwxNDIwMDAsODUwMDAsNjUwMDAsMTE1MDAwLDg3MDAwLDExMzAwMCw3OTAwMCwxNDEwMDAsMjAwMCwxMTAwMCw5ODAwMCw0NTAwMCwxNjEwMDAsNTAwMDAsMTI5MDAwLDEwNzAwMCwxNzAwMCw2ODAwMCw3MzAwMCwxNDcwMDAsODUwMDAsNzQwMDAsMTAwMCw0NzAwMCwxNzAwMCwxMjIwMDAsMTAwMCwxNTMwMDAsMTI4MDAwLDYzMDAwLDEwMDAsMTI4MDAwLDE1NjAwMCwxNjUwMDAsODQwMDAsMTU0MDAwLDc5MDAwLDE4NTAwMCwyMDAwLDM2MDAwLDQ1MDAwLDEwMDAsMTU3MDAwLDE4NjAwMF0sIm9wcyI6Nzc0ODB9XSwidXBkYXRlZCI6IjIwMjMtMDMtMDdUMjA6MTU6NDUuMjgwWiJ9)** than current implementation.

Regular expression ordering also prioritizes most common characters first.

I also don't see much reason to escape `"` (double quotes), since the `escapeString()` function is only used in places where the wrapper is always single quotes. I kept it because other code is tested this way, but in practice, there shouldn't be any side effects.

New tests added just to double-check that. All works as expected.