### PR TITLE
[misc] github workflows support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,136 @@
+name: Build
+on: [push]
+jobs:
+  eslint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 19
+
+      - run: npm install
+      - run: npm run test:lint
+
+  prettier:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 19
+
+      - run: npm install
+      - run: npm run test:prettier
+
+  types:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 19
+
+      - run: npm install
+      - run: npm run test:types
+
+  types-prettier:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 19
+
+      - run: npm install
+      - run: npm run test:types-prettier
+
+  test:
+    runs-on: ubuntu-latest
+
+    needs:
+      - eslint
+      - prettier
+      - types
+      - types-prettier
+
+    strategy:
+      matrix:
+        databases:
+          - mariadb:10.4
+          - mariadb:10.5
+          - mariadb:10.6
+          - mariadb:10.9
+          - mariadb:10.10
+          - mariadb:10.11
+          - mariadb:11.0-rc
+
+    services:
+      mariadb:
+        image: ${{ matrix.databases }}
+        ports:
+          - 3306:3306
+        env:
+          MARIADB_ROOT_PASSWORD: password
+          MARIADB_USER: user
+          MARIADB_PASSWORD: password
+          MARIADB_DATABASE: testn
+        options: >-
+          --health-cmd="mariadb-admin ping"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=3
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 19
+
+      - run: npm install
+      - run: npm run test:base
+        env:
+          TEST_DB_PASSWORD: password
+
+  coverage-test:
+    runs-on: ubuntu-latest
+    needs: test
+
+    strategy:
+      matrix:
+        databases:
+          - mariadb:10.6
+          - mariadb:10.11
+          - mariadb:11.0-rc
+
+    services:
+      mariadb:
+        image: ${{ matrix.databases }}
+        ports:
+          - 3306:3306
+        env:
+          MARIADB_ROOT_PASSWORD: password
+          MARIADB_PASSWORD: password
+          MARIADB_DATABASE: testn
+        options: >-
+          --health-cmd="mariadb-admin ping"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=3
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 19
+
+      - run: npm install
+      - run: npm run coverage:test
+        env:
+          TEST_DB_PASSWORD: password

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,21 +1,19 @@
-
 # Contribution
 
-Developers interested in contributing to the MariaDB Node.js Connector can do so through GitHub.  Each pull request should address a single issue, and contain both the fix as well as a description of how the changes work and tests to validate that the pull request fixes the issue in question.
+Developers interested in contributing to the MariaDB Node.js Connector can do so through GitHub. Each pull request should address a single issue, and contain both the fix as well as a description of how the changes work and tests to validate that the pull request fixes the issue in question.
 
-In the event that you would like to contribute to the development a significant feature, we like to have an open issue on the [MariaDB JIRA](https://jira.mariadb.org/projects/CONJS).  
+In the event that you would like to contribute to the development a significant feature, we like to have an open issue on the [MariaDB JIRA](https://jira.mariadb.org/projects/CONJS).
 Discussions of the issue will take place on the JIRA ticket.
 
 ## Development
 
-Rather than downloading the source code for the Connector directly from GitHub or cloning this repository, instead fork the project onto your own account.  
+Rather than downloading the source code for the Connector directly from GitHub or cloning this repository, instead fork the project onto your own account.
 Then send pull requests from your fork.
 
 ### Testing
 
-Before submitting a pull request to the project, run local and continuous integration testing.  
+Before submitting a pull request to the project, run local and continuous integration testing.
 This ensures that your patch works and can be accepted without breaking the Connector, and if code doesn't follow default code style, it will be automatically corrected
-
 
 #### Running Local Tests
 
@@ -25,55 +23,58 @@ Run local tests using npm.
 In order for these tests to pass, you need to have a MariaDB or MySQL server installed, which by default it assumes is running at localhost:3306 with a database named `testn` and a user `root` without a password.
 Alternatively you will need to create a user [with grant privilege](https://mariadb.com/kb/en/grant/#the-grant-option-privilege).
 Example, with `root` user create the new user and grant privileges:
+
 ```
 MariaDB [(none)]> create user anel@localhost identified by ('testpass');
 MariaDB [(none)]> grant all privileges on *.* to anel@localhost WITH GRANT OPTION;
 ```
+
 Once this is set up, you can run the tests with npm:
 
 ```
 $ npm run test:base
 ```
+
 Or via environment variables with specific user:
+
 ```
-$ TEST_DB=testn TEST_USER=anel TEST_PASSWORD=testpass TEST_PORT=3306 TEST_HOST=localhost npm run test:base
+$ TEST_DB_DATABASE=testn TEST_DB_USER=anel TEST_DB_PASSWORD=testpass TEST_DB_PORT=3306 TEST_HOST=localhost npm run test:base
 ```
+
 The tests retrieve the host, password, database and port number from environmental variables, which you can manually set if you want to connect to MariaDB in other ways.
 
-* `TEST_HOST` Hostname.  By default, localhost.
-* `TEST_PASSWORD` Password for `root`.  Null by default.
-* `TEST_DB` Database to run tests on.  Defaults to `testn`.
-* `TEST_PORT` Port to connect to. 3306 by default.
+- `TEST_HOST` Hostname. By default, localhost.
+- `TEST_DB_PASSWORD` Password for `root`. Null by default.
+- `TEST_DB_DATABASE` Database to run tests on. Defaults to `testn`.
+- `TEST_DB_PORT` Port to connect to. 3306 by default.
 
-
-On Windows, you can launch specific tests by calling them.  For instance,
+On Windows, you can launch specific tests by calling them. For instance,
 
 ```
-node.exe .\node_modules\mocha\bin\_mocha .\test\integration\test.js 
+node.exe .\node_modules\mocha\bin\_mocha .\test\integration\test.js
 ```
 
 Or, you can run the entire test suite:
 
 ```
-npm test 
+npm test
 ```
 
 #### Running CI test
 
-Continuous Integration testing for the Connector is set for [travis](https://app.travis-ci.com/github/mariadb-corporation/mariadb-connector-nodejs/).   
+Continuous Integration testing for the Connector is set for [travis](https://app.travis-ci.com/github/mariadb-corporation/mariadb-connector-nodejs/).
 You can test your own code using either, provided you configure them to validate your fork, rather than the project repository.
 
-The advantage of CI tools over running tests locally is that it launches tests for different versions of Node.js and different versions of MariaDB and MySQL servers.  This to ensure that your patch will work across other builds, in addition to the one you have on your local system.
+The advantage of CI tools over running tests locally is that it launches tests for different versions of Node.js and different versions of MariaDB and MySQL servers. This to ensure that your patch will work across other builds, in addition to the one you have on your local system.
 
-In order to do that, go to [Travis CI](https://app.travis-ci.com/github/), connect your GitHub account and active your fork of the MariaDB Connector repository.  Once this is done, Travis runs tests against every push you make to your repository on GitHub.
-
+In order to do that, go to [Travis CI](https://app.travis-ci.com/github/), connect your GitHub account and active your fork of the MariaDB Connector repository. Once this is done, Travis runs tests against every push you make to your repository on GitHub.
 
 #### Coverage test
 
 To ensure coverage of new code is well tested, you can run coverage tests.
 
 ```
-npm install nyc -g 
+npm install nyc -g
 nyc npm test
 ```
 
@@ -81,7 +82,7 @@ results will be :
 
 ```
   ... will run tests
-  
+
   263 passing (50s)
   9 pending
 
@@ -95,7 +96,7 @@ All files                                        |    95.71 |    84.26 |    90.3
  mariadb-connector-nodejs/lib                    |    93.82 |    82.38 |    88.33 |    93.92 |                   |
   connection-callback.js                         |      100 |    96.97 |      100 |      100 |                77 |
   connection.js                                  |    94.13 |    79.33 |    90.28 |    94.13 |... 42,644,645,663 |
-...                                              |          |          |          |          |                   | 
+...                                              |          |          |          |          |                   |
  mariadb-connector-nodejs/lib/misc               |      100 |    97.91 |      100 |      100 |                   |
   connection-information.js                      |      100 |      100 |      100 |      100 |                   |
   errors.js                                      |      100 |    81.82 |      100 |      100 |        9,11,13,22 |
@@ -103,7 +104,6 @@ All files                                        |    95.71 |    84.26 |    90.3
   utils.js                                       |      100 |      100 |      100 |      100 |                   |
 -------------------------------------------------|----------|----------|----------|----------|-------------------|
 ```
-
 
 ### Submitting Pull Requests
 
@@ -114,4 +114,3 @@ Please detail what the pull request does in your request.
 # License
 
 Distributed under the terms of the GNU Library or "Lesser" General Public License (LGPL).
-


### PR DESCRIPTION
This PR add support to **Github Workflows/Actions**.

It will run `test:lint`, `test:prettier`, `test:types`, `test:types-prettier`, then will run test:base over MariaDB _10.4_, _10.5_, _10.6_ (LTS), _10.9_, _10.10_, _10.11_ (LTS) and _11.0-rc_ (EOL >= 6 months).

I also updated `CONTRIBUTION.md` to fix envinroment variable names.