### PR TITLE
Fix decoding unsigned MEDIUMINT in binary decoder

### DIFF
--- a/lib/cmd/decoder/binary-decoder.js
+++ b/lib/cmd/decoder/binary-decoder.js
@@ -160,7 +160,7 @@ const readMediumBinaryUnsigned = (packet, opts, throwUnexpectedError, nullBitmap
   if (isNullBitmap(index, nullBitmap)) {
     return null;
   }
-  const result = packet.readInt24();
+  const result = packet.readUInt24();
   packet.skip(1); // MEDIUMINT is encoded on 4 bytes in exchanges !
   return result;
 };


### PR DESCRIPTION
They are currently decoded as signed by mistake.