### PR TITLE
Add missing QueryOptions type to prepare function

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -658,7 +658,7 @@ export interface Connection extends events.EventEmitter {
   /**
    * Prepare query.
    */
-  prepare(sql: string): Promise<Prepare>;
+  prepare(sql: string | QueryOptions): Promise<Prepare>;
 
   /**
    * Execute query using binary (prepare) protocol


### PR DESCRIPTION
The types currently only allow strings as prepare parameter. The implementation and documentation looks like it supports query options as parameters.

## Implementation: 

https://github.com/mariadb-corporation/mariadb-connector-nodejs/blob/b65aca10b77f5ede83f16a8edd0537b2ef12a16f/lib/connection-promise.js#L119-L130

## Documentation: 

https://github.com/mariadb-corporation/mariadb-connector-nodejs/blob/b65aca10b77f5ede83f16a8edd0537b2ef12a16f/documentation/promise-api.md?plain=1#L991-L992