### PR TITLE
Fix prepared close and cache access

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -1083,15 +1083,17 @@ class Connection extends EventEmitter {
    * @param cmd         command
    * @private
    */
-  addCommandEnable(cmd) {
+  addCommandEnable(cmd, skipReceive) {
     cmd.once('end', this._sendNextCmdImmediate.bind(this));
 
     //send immediately only if no current active receiver
     if (this.sendQueue.isEmpty() && this.receiveQueue.isEmpty()) {
-      this.receiveQueue.push(cmd);
+      if (!skipReceive)
+        this.receiveQueue.push(cmd);
       cmd.start(this.streamOut, this.opts, this.info);
     } else {
-      this.receiveQueue.push(cmd);
+      if (!skipReceive)
+        this.receiveQueue.push(cmd);
       this.sendQueue.push(cmd);
     }
   }
@@ -1102,10 +1104,11 @@ class Connection extends EventEmitter {
    * @param cmd         command
    * @private
    */
-  addCommandEnablePipeline(cmd) {
+  addCommandEnablePipeline(cmd, skipReceive) {
     cmd.once('send_end', this._sendNextCmdImmediate.bind(this));
 
-    this.receiveQueue.push(cmd);
+    if (!skipReceive)
+      this.receiveQueue.push(cmd);
     if (this.sendQueue.isEmpty()) {
       cmd.start(this.streamOut, this.opts, this.info);
       if (cmd.sending) {
@@ -1786,7 +1789,8 @@ class Connection extends EventEmitter {
         () => {},
         () => {},
         prepareResultPacket
-      )
+      ),
+      true
     );
   }
 

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -365,7 +365,8 @@ class Connection extends EventEmitter {
       const resetCmd = new Reset(
         cmdParam,
         () => {
-          conn.prepareCache.reset();
+          if (conn.prepareCache)
+            conn.prepareCache.reset();
           let prom = Promise.resolve();
           // re-execute init query / session query timeout
           prom


### PR DESCRIPTION
Closing a prepared statement does not result in a server response, so prior to these changes `prepared.close()` would end up blocking any further enqueued commands on the connection because it was adding to the receive queue.

Additionally there was a bug when resetting a connection and the prepared statement cache was not being used.