### PR TITLE
Add missing BIGINT Type enum

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1017,7 +1017,8 @@ export const enum Types {
   BLOB = 'BLOB',
   VAR_STRING = 'VAR_STRING',
   STRING = 'STRING',
-  GEOMETRY = 'GEOMETRY'
+  GEOMETRY = 'GEOMETRY',
+  BIGINT = 'BIGINT'
 }
 
 export interface Collation {


### PR DESCRIPTION
I was trying to cast any BIGINT numbers to strings so that I can serialize my results to JSON, But  it seems like BIGINT was missing as a enum in the Types enum, this commit fixes the issue

```ts
    typeCast: (field, next): => {

        // Property 'BIGINT' does not exist on type 'typeof Types'.ts(2339)
        if (field.type === Types.BIGINT) {
            return field.string()
        }

        return next()

    }
```