### PR TITLE
Update tests for ephemeral certificates in MaxScale

### DIFF
--- a/test/base.js
+++ b/test/base.js
@@ -97,7 +97,7 @@ module.exports.isMaxscaleMinVersion = function isMaxscaleMinVersion(major, minor
     };
   }
 
-  let ver = this.maxscaleVersion;
+  let ver = global.maxscaleVersion;
   return (
     ver.major > major ||
     (ver.major === major && ver.minor > minor) ||


### PR DESCRIPTION
The tests now take into account the added ephemeral certificate handling in MaxScale.

Also fixed a minor bug in the MaxScale version check code.