### PR TITLE
Update MaxScale versions

### DIFF
--- a/test/integration/test-ssl.js
+++ b/test/integration/test-ssl.js
@@ -135,7 +135,8 @@ describe('ssl', function () {
     } else if (
       !shareConn.info.isMariaDB() ||
       !shareConn.info.hasMinVersion(11, 4, 0) ||
-      shareConn.info.hasMinVersion(23, 0, 0)
+      shareConn.info.hasMinVersion(23, 0, 0) ||
+      (isMaxscale() && !isMaxscaleMinVersion(25, 8, 0)))
     )
       this.skip();
     let conn = null;

--- a/test/integration/test-ssl.js
+++ b/test/integration/test-ssl.js
@@ -103,7 +103,7 @@ describe('ssl', function () {
     // skip for ephemeral, since will succeed
     if (shareConn.info.isMariaDB() && shareConn.info.hasMinVersion(11, 4, 0) && !shareConn.info.hasMinVersion(23, 0, 0))
       this.skip();
-    if (isMaxscale() && isMaxscaleMinVersion(25, 0, 0)) this.skip();
+    if (isMaxscale() && isMaxscaleMinVersion(25, 8, 0)) this.skip();
     try {
       conn = await base.createConnection({
         user: 'sslTestUser',
@@ -129,8 +129,8 @@ describe('ssl', function () {
   it('signed certificate error with ephemeral', async function () {
     if (!sslEnable) this.skip();
     let isMaxscaleEphemeral = false;
-    if (isMaxscale() && isMaxscaleMinVersion(25, 0, 0)) {
-      // MaxScale implements this in the 25.xx release
+    if (isMaxscale() && isMaxscaleMinVersion(25, 8, 0)) {
+      // MaxScale implements this in the 25.08 release
       isMaxscaleEphemeral = true;
     } else if (
       !shareConn.info.isMariaDB() ||


### PR DESCRIPTION
The exact version in which the ephemeral certificate handling will be implemented is 25.08.

Also made the ephemeral certificate test case handle the case where an older MaxScale is used with MariaDB 11.4 or newer.