### PR TITLE
chore: move @types/geojson and @types/node to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,13 +48,13 @@
   "author": "Diego Dupin <diego.dupin@mariadb.com>",
   "license": "LGPL-2.1-or-later",
   "dependencies": {
-    "@types/geojson": "^7946.0.14",
-    "@types/node": "^22.5.4",
     "denque": "^2.1.0",
     "iconv-lite": "^0.6.3",
     "lru-cache": "^10.3.0"
   },
   "devDependencies": {
+    "@types/geojson": "^7946.0.14",
+    "@types/node": "^22.5.4",
     "@typescript-eslint/eslint-plugin": "^7.18.0",
     "@typescript-eslint/parser": "^7.18.0",
     "benchmark": "^2.1.4",


### PR DESCRIPTION
There is no need to download type definitions in production environments, as they are only required for development.

Closes #309.