### PR TITLE
SSL Identity Check Bypass

### DIFF
--- a/documentation/connection-options.md
+++ b/documentation/connection-options.md
@@ -173,6 +173,7 @@ JSON object:
 
 |option|description|type|default| 
 |---:|---|:---:|:---:| 
+|**servername**| A string with the host name to use with SNI if different to host | *string*|
 |**checkServerIdentity**| `function(servername, cert)` to replace SNI default function| *Function*|
 |**minDHSize**| Minimum size of the DH parameter in bits to accept a TLS connection | *number*|1024|
 |**pfx**| Optional PFX or PKCS12 encoded private key and certificate chain. Encrypted PFX will be decrypted with `passphrase` if provided| *string / string[] / Buffer / Buffer[] / *Object[]*|

--- a/lib/cmd/handshake/authentication.js
+++ b/lib/cmd/handshake/authentication.js
@@ -97,7 +97,7 @@ class Authentication extends Command {
             }
             return this.throwNewError('self-signed certificate', true, info, '08000', Errors.ER_SELF_SIGNED);
           } else if (info.requireIdentifyCheck) {
-            const identityError = tls.checkServerIdentity(opts.host, info.tlsCert);
+            const identityError = tls.checkServerIdentity(typeof opts.ssl === 'object' && opts.ssl.servername ? opts.ssl.servername : opts.host, info.tlsCert);
             if (identityError) {
               return this.throwNewError(
                 'certificate identify Error: ' + identityError.message,

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -1339,14 +1339,13 @@ class Connection extends EventEmitter {
       this.opts.ssl === true ||
       this.opts.ssl.rejectUnauthorized === undefined ||
       this.opts.ssl.rejectUnauthorized === true;
-    info.requireIdentifyCheck = this.opts.ssl === true || this.opts.ssl.checkServerIdentity === undefined;
+    info.requireIdentifyCheck = this.opts.ssl === true || this.opts.ssl.checkServerIdentity !== undefined;
     const baseConf = {
       servername: this.opts.host,
       socket: this.socket,
       rejectUnauthorized: false,
-      checkServerIdentity: () => {}
     };
-    const sslOption = this.opts.ssl === true ? baseConf : Object.assign({}, this.opts.ssl, baseConf);
+    const sslOption = this.opts.ssl === true ? baseConf : Object.assign({}, baseConf, this.opts.ssl);
 
     try {
       const secureSocket = tls.connect(sslOption, callback);


### PR DESCRIPTION
Fixes #313

Adds support for servername property for SNI. 

I also removed that checkServerIdentity: () => {} from the baseConfig as it did not appear to be used, and could end up in another bypass.