### PR TITLE
Fix issue with connections breaking due to subsequent errors occurring (createPool)

### DIFF
--- a/lib/pool.js
+++ b/lib/pool.js
@@ -237,6 +237,7 @@ class Pool extends EventEmitter {
     conn.on('error', () => {
       // Only need to handle one error, however ensure that subsequent errors do not crash node instance
       if (alreadyProcessedError) return;
+      alreadyProcessedError = true
 
       // Clean up this connection
       pool._endLeak(conn);


### PR DESCRIPTION
If a connection throws multiple errors two potential error cases can occur: `unhandledRejection` or `uncaughtException`
- This occurs if the mariadb socket connection unexpectedly closes, via server crashing, docker stop|docker compose down.

Fixes #323 