### PR TITLE
Manage minimumIdle at value 0

### DIFF
--- a/lib/pool.js
+++ b/lib/pool.js
@@ -467,11 +467,13 @@ class Pool extends EventEmitter {
   }
 
   _shouldCreateMoreConnections() {
+    const hasPendingRequests = this.#requests.length > 0;
+    const needsMinimumIdle = this.#idleConnections.length < this.opts.minimumIdle;
+    const hasCapacity = this.totalConnections() < this.opts.connectionLimit;
+    const needsConnectionsForRequests = hasPendingRequests && this.#idleConnections.length === 0;
+
     return (
-      !this.#connectionInCreation &&
-      this.#idleConnections.length < this.opts.minimumIdle &&
-      this.totalConnections() < this.opts.connectionLimit &&
-      !this.#closed
+      !this.#connectionInCreation && (needsMinimumIdle || needsConnectionsForRequests) && hasCapacity && !this.#closed
     );
   }
 

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -434,6 +434,7 @@ class Pool extends EventEmitter {
   _stopConnectionReaping() {
     if (this.#unusedConnectionRemoverId && this.totalConnections() === 0) {
       clearInterval(this.#unusedConnectionRemoverId);
+      this.#unusedConnectionRemoverId = null;
     }
   }
 


### PR DESCRIPTION
This allows using the pool with minimumIdle = 0 and makes the _shouldCreateMoreConnections function easier to read.

Additionally, the variable that holds the reaping timer should be set to null after it’s cleared. This prevents potential issues that block the release of unused connections, even after their timeOut has elapsed. I’m fixing it here because, in some tests, race conditions can leave connections open when they shouldn’t be.

This close #329 and #331 