### PR TITLE
Fix: broken image link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p style="text-align: center;">
   <a href="https://mariadb.com/">
-    <img src="https://mariadb.com/wp-content/themes/mariadb-2025/public/images/logo-dark.4482a1.svg"/>
+    <img src="https://mariadb.com/wp-content/uploads/2019/11/mariadb-horizontal-blue.svg"/>
   </a>
 </p>
 


### PR DESCRIPTION
Fixing the logo in your README file.

I use the **blue** link **SVG** horizontal logo from: https://mariadb.com/about-us/logos/. 

Note that the "black" logo version can cause issues when using GitHub in dark theme (like I have). But the blue is _somewhat_ acceptable for both white & black themes within GitHub.

