### PR TITLE
Add missing pingTimeout connection option to types

### DIFF
--- a/types/share.d.ts
+++ b/types/share.d.ts
@@ -113,6 +113,13 @@ export interface PoolConfig extends ConnectionConfig {
    * A value of 0 (default) meaning Leak detection is disabled
    */
   leakDetectionTimeout?: number;
+
+  /**
+   * Validation timeout (ping) for checking an connection not used recently from pool.
+   * In milliseconds.
+   * Default: 500
+   */
+  pingTimeout?: number;
 }
 
 export interface PoolClusterConfig {


### PR DESCRIPTION
Description taken from https://mariadb.com/docs/connectors/mariadb-connector-nodejs/connector-nodejs-promise-api

This fixes issue #344 