### PR TITLE
Prototype-chain merge instead of a flat clone

### DIFF
--- a/lib/cmd/parser.js
+++ b/lib/cmd/parser.js
@@ -41,7 +41,7 @@ class Parser extends Command {
     super(cmdParam, resolve, reject);
     this._responseIndex = 0;
     this._rows = [];
-    this.opts = cmdParam.opts ? Object.assign({}, connOpts, cmdParam.opts) : connOpts;
+    this.opts = cmdParam.opts ? Object.assign(Object.create(connOpts), cmdParam.opts) : connOpts;
     this.sql = cmdParam.sql;
     this.initialValues = cmdParam.values;
     this.canSkipMeta = false;


### PR DESCRIPTION
connOpts can be up to ~62 properties. Cloning the object means 62 allocations - this patch swaps to a prototype-chain merge instead of a flat clone and thus reduces allocations from 62 to 2

Not sure how welcome perf-only changes are -- I'm looking forward to contributing more substantially in the future!