### PR TITLE
feature: export Types for both promise and callback api

### DIFF
--- a/callback.js
+++ b/callback.js
@@ -13,9 +13,10 @@ import ClusterOptions from './lib/config/cluster-options.js';
 import Connection from './lib/connection.js';
 import * as SqlError from './lib/misc/errors.js';
 import packageJson from './package.json' with { type: 'json' };
+import { TYPES } from './lib/const/field-type.js';
 
 export const version = packageJson.version;
-export { SqlError };
+export { SqlError, TYPES as Types };
 
 export function defaultOptions(opts) {
   const connOpts = new ConnOptions(opts);

--- a/promise.js
+++ b/promise.js
@@ -13,10 +13,11 @@ import PoolOptions from './lib/config/pool-options.js';
 import ClusterOptions from './lib/config/cluster-options.js';
 import * as SqlError from './lib/misc/errors.js';
 import packageJson from './package.json' with { type: 'json' };
+import { TYPES } from './lib/const/field-type.js';
 
 export const version = packageJson.version;
 
-export { SqlError };
+export { SqlError, TYPES as Types };
 
 export function defaultOptions(opts) {
   const connOpts = new ConnOptions(opts);


### PR DESCRIPTION
Fix for: [347](https://github.com/mariadb-corporation/mariadb-connector-nodejs/issues/347)