### PR TITLE
Fix SqlError losing its constructor shape via namespace import

### DIFF
--- a/callback.js
+++ b/callback.js
@@ -11,7 +11,7 @@ import ConnOptions from './lib/config/connection-options.js';
 import PoolOptions from './lib/config/pool-options.js';
 import ClusterOptions from './lib/config/cluster-options.js';
 import Connection from './lib/connection.js';
-import * as SqlError from './lib/misc/errors.js';
+import SqlError from './lib/misc/errors.js';
 import packageJson from './package.json' with { type: 'json' };
 import { Types, TypeNumbers } from './lib/const/field-type.js';
 

--- a/promise.js
+++ b/promise.js
@@ -11,7 +11,7 @@ import Cluster from './lib/cluster.js';
 import ConnOptions from './lib/config/connection-options.js';
 import PoolOptions from './lib/config/pool-options.js';
 import ClusterOptions from './lib/config/cluster-options.js';
-import * as SqlError from './lib/misc/errors.js';
+import SqlError from './lib/misc/errors.js';
 import packageJson from './package.json' with { type: 'json' };
 import { Types, TypeNumbers } from './lib/const/field-type.js';
 

--- a/test/import/cjs.cjs
+++ b/test/import/cjs.cjs
@@ -33,6 +33,10 @@ function check(label, mod) {
   // so consumers that did `const mariadb = require('mariadb').default` keep working.
   assert.ok(mod.default, `${label}: default export is missing`);
   assert.strictEqual(typeof mod.default.createPool, 'function', `${label}: default.createPool is not a function`);
+
+  assert.strictEqual(typeof mod.SqlError, 'function', `${label}: SqlError is not a constructor`);
+  assert.ok(!(new Error('x') instanceof mod.SqlError), `${label}: plain Error must not be instanceof SqlError`);
+  assert.ok(new mod.SqlError('x') instanceof mod.SqlError, `${label}: SqlError instance fails instanceof SqlError`);
 }
 
 check("require('mariadb')", require('mariadb'));

--- a/test/import/esm.mjs
+++ b/test/import/esm.mjs
@@ -9,7 +9,7 @@
 import assert from 'node:assert';
 import mariadb, { createPool, createConnection, version, SqlError } from 'mariadb';
 import * as mariadbNs from 'mariadb';
-import mariadbCb, { createPool as createPoolCb } from 'mariadb/callback';
+import mariadbCb, { createPool as createPoolCb, SqlError as SqlErrorCb } from 'mariadb/callback';
 
 const expectedNamed = [
   'SqlError',
@@ -31,6 +31,9 @@ assert.strictEqual(typeof createPool, 'function', 'named createPool is not a fun
 assert.strictEqual(typeof createConnection, 'function', 'named createConnection is not a function');
 assert.strictEqual(typeof version, 'string', 'named version is not a string');
 assert.ok(SqlError, 'named SqlError missing');
+assert.strictEqual(typeof SqlError, 'function', 'named SqlError is not a constructor');
+assert.ok(!(new Error('x') instanceof SqlError), 'plain Error must not be instanceof SqlError');
+assert.ok(new SqlError('x') instanceof SqlError, 'SqlError instance fails instanceof SqlError');
 
 // namespace import
 for (const key of expectedNamed) {
@@ -41,5 +44,8 @@ for (const key of expectedNamed) {
 assert.ok(mariadbCb, '/callback default export missing');
 assert.strictEqual(typeof mariadbCb.createPool, 'function', '/callback default.createPool is not a function');
 assert.strictEqual(typeof createPoolCb, 'function', '/callback named createPool is not a function');
+assert.strictEqual(typeof SqlErrorCb, 'function', '/callback named SqlError is not a constructor');
+assert.ok(new SqlErrorCb('x') instanceof SqlErrorCb, '/callback SqlError instance fails instanceof SqlError');
+assert.strictEqual(typeof mariadbCb.SqlError, 'function', '/callback default.SqlError is not a constructor');
 
 console.log('ESM import smoke test: OK');


### PR DESCRIPTION
Fixes #348

\`errors.js\` exports \`SqlError\` as a default export (\`export default class SqlError extends Error\`), but \`promise.js\` and \`callback.js\` both import it with \`import * as SqlError\`. That binds the module namespace object, not the class - so the public \`SqlError\` export ends up as a plain object instead of a constructor, and \`err instanceof SqlError\` throws \`TypeError: Right-hand side of 'instanceof' is not callable\`.

The type declarations already expect a constructor (\`types/share.d.ts:424\`, \`declare const SqlError: SqlErrorConstructor\`), so this is a runtime/type mismatch, not just a missing check.

Fix is a one-line import change in each entry file (default import instead of namespace import). Also extended the existing import smoke tests (promise/callback, ESM/CJS) to assert \`SqlError\` is actually a constructor and that \`instanceof\` works - the previous checks only asserted the export was truthy, which a namespace object also satisfies, so they didn't catch this.

Tests:

- \`npm run test:imports\`
- \`npm run test:cts\`
- \`npm run test:lint\`